### PR TITLE
Fixes invalid single-digit date input and compiler warnings

### DIFF
--- a/lib/edtf/aggregate.ex
+++ b/lib/edtf/aggregate.ex
@@ -13,8 +13,15 @@ defmodule EDTF.Aggregate do
           later: boolean()
         }
 
-  def assemble({:list, value}), do: %__MODULE__{assemble(value) | type: :list}
-  def assemble({:set, value}), do: %__MODULE__{assemble(value) | type: :set}
+  def assemble({:list, value}) do
+    %__MODULE__{} = result = assemble(value)
+    %{result | type: :list}
+  end
+
+  def assemble({:set, value}) do
+    %__MODULE__{} = result = assemble(value)
+    %{result | type: :set}
+  end
 
   def assemble(value) do
     dates =

--- a/lib/edtf/parser.ex
+++ b/lib/edtf/parser.ex
@@ -113,7 +113,7 @@ defmodule EDTF.Parser do
 
   edtf_year =
     choice([
-      optional(ignore(ascii_char([?Y]))) |> concat(qualified_year),
+      ignore(ascii_char([?Y])) |> concat(qualified_year),
       lookahead(choice([exponent, significant])) |> concat(qualified_year)
     ])
     |> tag(

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,14 @@ defmodule EDTF.MixProject do
         main: "readme",
         extras: ["README.md"]
       ],
-      preferred_cli_env: [
+      test_coverage: [tool: ExCoveralls],
+      elixirc_paths: elixirc_paths(Mix.env())
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
         coveralls: :test,
         "coveralls.circle": :test,
         "coveralls.detail": :test,
@@ -32,9 +39,7 @@ defmodule EDTF.MixProject do
         "vcr.delete": :test,
         "vcr.check": :test,
         "vcr.show": :test
-      ],
-      test_coverage: [tool: ExCoveralls],
-      elixirc_paths: elixirc_paths(Mix.env())
+      ]
     ]
   end
 

--- a/test/edtf_test.exs
+++ b/test/edtf_test.exs
@@ -15,4 +15,17 @@ defmodule EDTFTest do
     assert EDTF.parse("bad date!") == {:error, :invalid_format}
     assert EDTF.parse("2020-%06-25?") == {:error, :invalid_format}
   end
+
+  test "rejects unprefixed short-digit years (ISO 8601-2 requires Y prefix or 4-digit form)" do
+    assert EDTF.parse("1") == {:error, :invalid_format}
+    assert EDTF.humanize("1") == {:error, :invalid_format}
+    assert EDTF.validate("1") == {:error, :invalid_format}
+
+    assert EDTF.parse("0001") ==
+             {:ok, %EDTF.Date{level: 0, type: :date, values: [1]}}
+
+    assert EDTF.parse("Y20020") ==
+             {:ok,
+              %EDTF.Date{level: 1, type: :year, values: [20_020], attributes: [significant: nil]}}
+  end
 end


### PR DESCRIPTION
Hey there I just noticed parse allows single-digit strings what is not compliant with ISO-8601-2

I also fixed compiler warnings for the current Elixir version.