### PR TITLE
Generating date ranges for filtering and sorting multiple EDTF dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 
 ## Usage
 
-See `EDTF.parse/1`, `EDTF.validate/1`, and `EDTF.humanize/1`.
+See `EDTF.parse/1`, `EDTF.validate/1`, `EDTF.humanize/1`, and `EDTF.to_date_range/1`.
 
 ## Notes
 

--- a/lib/edtf.ex
+++ b/lib/edtf.ex
@@ -69,4 +69,43 @@ defmodule EDTF do
       other -> other
     end
   end
+
+  @doc """
+  Convert an EDTF date string (or a previously parsed `EDTF.Date`,
+  `EDTF.Interval`, or `EDTF.Aggregate` struct) into a `{start_date, end_date}`
+  tuple of `Date.t()` values.
+
+  Unbounded inputs (`/..`, `../`, unknown bounds, aggregate `..`-continuations)
+  produce `nil` on that side. Qualifiers (`~`, `?`, `%`) are ignored; the range
+  uses the nominal date. Unspecified-digit suffixes (e.g. `19XX`) expand to
+  their full span. See `EDTF.DateRange` for the full semantics.
+
+  Returns `{:error, :invalid_format}` when parsing fails, `{:error, :out_of_range}`
+  when `Date.new/3` itself rejects a value, and `{:error, :unsupported}` for
+  shapes the converter declines (e.g. fully-unknown year `XXXX` or non-suffix
+  unspecified digits like `X9X2`).
+
+  Example:
+    ```elixir
+    iex> to_date_range("1999-06-10")
+    {:ok, {~D[1999-06-10], ~D[1999-06-10]}}
+
+    iex> to_date_range("1985/..")
+    {:ok, {~D[1985-01-01], nil}}
+
+    iex> to_date_range("19XX")
+    {:ok, {~D[1900-01-01], ~D[1999-12-31]}}
+
+    iex> to_date_range("[1667, 1668, 1670..1672]")
+    {:ok, {~D[1667-01-01], ~D[1672-12-31]}}
+
+    iex> to_date_range("bad date!")
+    {:error, :invalid_format}
+    ```
+  """
+  def to_date_range(edtf) when is_binary(edtf) do
+    edtf |> parse() |> EDTF.DateRange.to_date_range()
+  end
+
+  def to_date_range(edtf), do: EDTF.DateRange.to_date_range(edtf)
 end

--- a/lib/edtf.ex
+++ b/lib/edtf.ex
@@ -75,10 +75,11 @@ defmodule EDTF do
   `EDTF.Interval`, or `EDTF.Aggregate` struct) into a `{start_date, end_date}`
   tuple of `Date.t()` values.
 
-  Unbounded inputs (`/..`, `../`, unknown bounds, aggregate `..`-continuations)
-  produce `nil` on that side. Qualifiers (`~`, `?`, `%`) are ignored; the range
-  uses the nominal date. Unspecified-digit suffixes (e.g. `19XX`) expand to
-  their full span. See `EDTF.DateRange` for the full semantics.
+  Explicitly open inputs (`/..`, `../`, aggregate `..`-continuations) produce
+  `:unbounded` on that side. Inputs with an unknown bound (`1985/`, `/1985`)
+  produce `:unknown`. Qualifiers (`~`, `?`, `%`) are ignored; the range uses
+  the nominal date. Unspecified-digit suffixes (e.g. `19XX`) expand to their
+  full span. See `EDTF.DateRange` for the full semantics.
 
   Returns `{:error, :invalid_format}` when parsing fails, `{:error, :out_of_range}`
   when `Date.new/3` itself rejects a value, and `{:error, :unsupported}` for
@@ -91,7 +92,7 @@ defmodule EDTF do
     {:ok, {~D[1999-06-10], ~D[1999-06-10]}}
 
     iex> to_date_range("1985/..")
-    {:ok, {~D[1985-01-01], nil}}
+    {:ok, {~D[1985-01-01], :unbounded}}
 
     iex> to_date_range("19XX")
     {:ok, {~D[1900-01-01], ~D[1999-12-31]}}

--- a/lib/edtf/aggregate.ex
+++ b/lib/edtf/aggregate.ex
@@ -13,8 +13,15 @@ defmodule EDTF.Aggregate do
           later: boolean()
         }
 
-  def assemble({:list, value}), do: %__MODULE__{assemble(value) | type: :list}
-  def assemble({:set, value}), do: %__MODULE__{assemble(value) | type: :set}
+  def assemble({:list, value}) do
+    %__MODULE__{} = result = assemble(value)
+    %{result | type: :list}
+  end
+
+  def assemble({:set, value}) do
+    %__MODULE__{} = result = assemble(value)
+    %{result | type: :set}
+  end
 
   def assemble(value) do
     dates =

--- a/lib/edtf/date_range.ex
+++ b/lib/edtf/date_range.ex
@@ -1,0 +1,255 @@
+defmodule EDTF.DateRange do
+  @moduledoc """
+  Convert parsed EDTF structs into a `{start_date, end_date}` tuple of
+  `Date.t()` values suitable for SQL- or Ecto-style range queries.
+
+  The user-facing entry point is `EDTF.to_date_range/1`, which accepts an EDTF
+  string and delegates here once parsing has succeeded. This module can also be
+  called directly with an already-parsed struct.
+
+  ## Semantics
+
+  - Bounded inputs yield two concrete `Date.t()` values.
+  - Unbounded inputs (`/..`, `../`, `[..2020]`, `[2020..]`, unknown bounds)
+    yield `nil` on the unbounded side.
+  - Qualifiers (`~`, `?`, `%`) are ignored — the range uses the nominal date.
+  - Unspecified digits (`X`) are expanded to their full place-value span when
+    they form a contiguous suffix of a component (e.g. `19XX` → 1900-01-01 to
+    1999-12-31). Non-suffix unspecified digits return `{:error, :unsupported}`.
+  - Seasons map to month ranges (quarters, quadrimesters, semesters are
+    unambiguous; codes 21–24 are treated as northern-hemisphere; Winter and
+    southern-hemisphere Summer span the year boundary).
+  """
+
+  import Bitwise
+
+  alias EDTF.{Aggregate, Infinity, Interval}
+
+  @season_months %{
+    21 => {3, 5},
+    22 => {6, 8},
+    23 => {9, 11},
+    24 => :winter_north,
+    25 => {3, 5},
+    26 => {6, 8},
+    27 => {9, 11},
+    28 => :winter_north,
+    29 => {9, 11},
+    30 => :summer_south,
+    31 => {3, 5},
+    32 => {6, 8},
+    33 => {1, 3},
+    34 => {4, 6},
+    35 => {7, 9},
+    36 => {10, 12},
+    37 => {1, 4},
+    38 => {5, 8},
+    39 => {9, 12},
+    40 => {1, 6},
+    41 => {7, 12}
+  }
+
+  @year_span_for_mask %{0 => 0, 8 => 9, 12 => 99, 14 => 999}
+
+  @doc """
+  Convert a parsed EDTF struct (or a `parse/1` result tuple) into a
+  `{start_date, end_date}` tuple.
+  """
+  def to_date_range({:ok, value}), do: to_date_range(value)
+  def to_date_range({:error, _} = error), do: error
+
+  def to_date_range(%EDTF.Date{} = date) do
+    mask = unspecified_mask(date)
+
+    if mask == 0 do
+      from_date(date)
+    else
+      from_unspecified(date, mask)
+    end
+  end
+
+  def to_date_range(%Interval{start: start_boundary, end: end_boundary}) do
+    with {:ok, start_range} <- resolve_boundary(start_boundary),
+         {:ok, end_range} <- resolve_boundary(end_boundary) do
+      {:ok, interval_envelope(start_range, end_range)}
+    end
+  end
+
+  def to_date_range(%Aggregate{values: []}), do: {:error, :unsupported}
+
+  def to_date_range(%Aggregate{values: values, earlier: earlier, later: later}) do
+    ranges =
+      values
+      |> Enum.map(&to_date_range/1)
+      |> Enum.flat_map(fn
+        {:ok, range} -> [range]
+        _ -> []
+      end)
+
+    case ranges do
+      [] ->
+        {:error, :unsupported}
+
+      _ ->
+        start_date = if earlier, do: nil, else: earliest_start(ranges)
+        end_date = if later, do: nil, else: latest_end(ranges)
+        {:ok, {start_date, end_date}}
+    end
+  end
+
+  def to_date_range(_), do: {:error, :unsupported}
+
+  defp from_date(%EDTF.Date{type: :date, values: [year, month, day]}) do
+    case Date.new(year, month + 1, day) do
+      {:ok, date} -> {:ok, {date, date}}
+      _ -> {:error, :out_of_range}
+    end
+  end
+
+  defp from_date(%EDTF.Date{type: :date, values: [year, month]}) do
+    month_range(year, month + 1)
+  end
+
+  defp from_date(%EDTF.Date{type: :date, values: [year]}), do: year_range(year)
+  defp from_date(%EDTF.Date{type: :year, values: [year]}), do: year_range(year)
+
+  defp from_date(%EDTF.Date{type: :decade, values: [decade]}) do
+    span_range(decade * 10, 9)
+  end
+
+  defp from_date(%EDTF.Date{type: :century, values: [century]}) do
+    span_range(century * 100, 99)
+  end
+
+  defp from_date(%EDTF.Date{type: :season, values: [year, code]}) do
+    season_range(year, Map.get(@season_months, code))
+  end
+
+  defp from_date(_), do: {:error, :unsupported}
+
+  defp from_unspecified(%EDTF.Date{values: values, type: :date}, mask) do
+    year_bits = mask &&& 15
+    month_bits = mask &&& 48
+    day_bits = mask &&& 192
+
+    cond do
+      year_bits == 15 ->
+        {:error, :unsupported}
+
+      year_bits != 0 and not Map.has_key?(@year_span_for_mask, year_bits) ->
+        {:error, :unsupported}
+
+      year_bits != 0 ->
+        span_range(hd(values), Map.fetch!(@year_span_for_mask, year_bits))
+
+      month_bits != 0 ->
+        year_range(hd(values))
+
+      day_bits != 0 and match?([_, _ | _], values) ->
+        [year, month | _] = values
+        month_range(year, month + 1)
+
+      true ->
+        {:error, :unsupported}
+    end
+  end
+
+  defp from_unspecified(_, _), do: {:error, :unsupported}
+
+  defp year_range(year), do: span_range(year, 0)
+
+  defp month_range(year, month) when month in 1..12 do
+    case Date.new(year, month, 1) do
+      {:ok, start_date} ->
+        end_date = Date.new!(year, month, Date.days_in_month(start_date))
+        {:ok, {start_date, end_date}}
+
+      _ ->
+        {:error, :out_of_range}
+    end
+  end
+
+  defp month_range(_, _), do: {:error, :out_of_range}
+
+  defp span_range(year, span) do
+    {start_year, end_year} = span_bounds(year, span)
+
+    with {:ok, start_date} <- Date.new(start_year, 1, 1),
+         {:ok, end_date} <- Date.new(end_year, 12, 31) do
+      {:ok, {start_date, end_date}}
+    else
+      _ -> {:error, :out_of_range}
+    end
+  end
+
+  # For BCE values, widen *away from zero* so the range matches the colloquial
+  # decade/century the humanize module prints (decade -201 → "2010s BCE" →
+  # years -2019..-2010, not -2010..-2001).
+  defp span_bounds(year, 0), do: {year, year}
+  defp span_bounds(year, span) when year >= 0, do: {year, year + span}
+  defp span_bounds(year, span), do: {year - span, year}
+
+  defp season_range(_year, nil), do: {:error, :unsupported}
+
+  defp season_range(year, :winter_north), do: cross_year_range(year, 12, year + 1, 2)
+  defp season_range(year, :summer_south), do: cross_year_range(year, 12, year + 1, 2)
+
+  defp season_range(year, {start_month, end_month}) do
+    with {:ok, start_date} <- Date.new(year, start_month, 1),
+         {:ok, end_pivot} <- Date.new(year, end_month, 1) do
+      end_date = Date.new!(year, end_month, Date.days_in_month(end_pivot))
+      {:ok, {start_date, end_date}}
+    else
+      _ -> {:error, :out_of_range}
+    end
+  end
+
+  defp cross_year_range(start_year, start_month, end_year, end_month) do
+    with {:ok, start_date} <- Date.new(start_year, start_month, 1),
+         {:ok, end_pivot} <- Date.new(end_year, end_month, 1) do
+      end_date = Date.new!(end_year, end_month, Date.days_in_month(end_pivot))
+      {:ok, {start_date, end_date}}
+    else
+      _ -> {:error, :out_of_range}
+    end
+  end
+
+  defp resolve_boundary(:unknown), do: {:ok, nil}
+  defp resolve_boundary(nil), do: {:ok, nil}
+  defp resolve_boundary(%Infinity{}), do: {:ok, nil}
+  defp resolve_boundary(%EDTF.Date{} = date), do: to_date_range(date)
+
+  defp interval_envelope(nil, nil), do: {nil, nil}
+  defp interval_envelope(nil, {_, b_end}), do: {nil, b_end}
+  defp interval_envelope({a_start, _}, nil), do: {a_start, nil}
+
+  defp interval_envelope({a_start, a_end}, {b_start, b_end}) do
+    {Enum.min([a_start, b_start], Date), Enum.max([a_end, b_end], Date)}
+  end
+
+  defp unspecified_mask(%EDTF.Date{attributes: attrs}) when is_list(attrs) do
+    Keyword.get(attrs, :unspecified) || 0
+  end
+
+  defp unspecified_mask(_), do: 0
+
+  defp earliest_start(ranges) do
+    ranges
+    |> Enum.map(fn {start_date, _} -> start_date end)
+    |> Enum.reject(&is_nil/1)
+    |> min_date()
+  end
+
+  defp latest_end(ranges) do
+    ranges
+    |> Enum.map(fn {_, end_date} -> end_date end)
+    |> Enum.reject(&is_nil/1)
+    |> max_date()
+  end
+
+  defp min_date([]), do: nil
+  defp min_date(dates), do: Enum.min(dates, Date)
+
+  defp max_date([]), do: nil
+  defp max_date(dates), do: Enum.max(dates, Date)
+end

--- a/lib/edtf/date_range.ex
+++ b/lib/edtf/date_range.ex
@@ -10,8 +10,10 @@ defmodule EDTF.DateRange do
   ## Semantics
 
   - Bounded inputs yield two concrete `Date.t()` values.
-  - Unbounded inputs (`/..`, `../`, `[..2020]`, `[2020..]`, unknown bounds)
-    yield `nil` on the unbounded side.
+  - Explicitly open inputs (`/..`, `../`, `[..2020]`, `[2020..]`) yield
+    `:unbounded` on the open side.
+  - Inputs with an unknown bound (`1985/`, `/1985`) yield `:unknown` on that
+    side.
   - Qualifiers (`~`, `?`, `%`) are ignored — the range uses the nominal date.
   - Unspecified digits (`X`) are expanded to their full place-value span when
     they form a contiguous suffix of a component (e.g. `19XX` → 1900-01-01 to
@@ -91,8 +93,8 @@ defmodule EDTF.DateRange do
         {:error, :unsupported}
 
       _ ->
-        start_date = if earlier, do: nil, else: earliest_start(ranges)
-        end_date = if later, do: nil, else: latest_end(ranges)
+        start_date = if earlier, do: :unbounded, else: earliest_start(ranges)
+        end_date = if later, do: :unbounded, else: latest_end(ranges)
         {:ok, {start_date, end_date}}
     end
   end
@@ -214,14 +216,16 @@ defmodule EDTF.DateRange do
     end
   end
 
-  defp resolve_boundary(:unknown), do: {:ok, nil}
-  defp resolve_boundary(nil), do: {:ok, nil}
-  defp resolve_boundary(%Infinity{}), do: {:ok, nil}
+  defp resolve_boundary(:unknown), do: {:ok, :unknown}
+  defp resolve_boundary(nil), do: {:ok, :unknown}
+  defp resolve_boundary(%Infinity{}), do: {:ok, :unbounded}
   defp resolve_boundary(%EDTF.Date{} = date), do: to_date_range(date)
 
-  defp interval_envelope(nil, nil), do: {nil, nil}
-  defp interval_envelope(nil, {_, b_end}), do: {nil, b_end}
-  defp interval_envelope({a_start, _}, nil), do: {a_start, nil}
+  defp interval_envelope(a, b) when a in [:unbounded, :unknown] and b in [:unbounded, :unknown],
+    do: {a, b}
+
+  defp interval_envelope(a, {_, b_end}) when a in [:unbounded, :unknown], do: {a, b_end}
+  defp interval_envelope({a_start, _}, b) when b in [:unbounded, :unknown], do: {a_start, b}
 
   defp interval_envelope({a_start, a_end}, {b_start, b_end}) do
     {Enum.min([a_start, b_start], Date), Enum.max([a_end, b_end], Date)}
@@ -236,20 +240,20 @@ defmodule EDTF.DateRange do
   defp earliest_start(ranges) do
     ranges
     |> Enum.map(fn {start_date, _} -> start_date end)
-    |> Enum.reject(&is_nil/1)
+    |> Enum.reject(&is_atom/1)
     |> min_date()
   end
 
   defp latest_end(ranges) do
     ranges
     |> Enum.map(fn {_, end_date} -> end_date end)
-    |> Enum.reject(&is_nil/1)
+    |> Enum.reject(&is_atom/1)
     |> max_date()
   end
 
-  defp min_date([]), do: nil
+  defp min_date([]), do: :unknown
   defp min_date(dates), do: Enum.min(dates, Date)
 
-  defp max_date([]), do: nil
+  defp max_date([]), do: :unknown
   defp max_date(dates), do: Enum.max(dates, Date)
 end

--- a/lib/edtf/parser.ex
+++ b/lib/edtf/parser.ex
@@ -113,7 +113,7 @@ defmodule EDTF.Parser do
 
   edtf_year =
     choice([
-      optional(ignore(ascii_char([?Y]))) |> concat(qualified_year),
+      ignore(ascii_char([?Y])) |> concat(qualified_year),
       lookahead(choice([exponent, significant])) |> concat(qualified_year)
     ])
     |> tag(

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,14 @@ defmodule EDTF.MixProject do
         main: "readme",
         extras: ["README.md"]
       ],
-      preferred_cli_env: [
+      test_coverage: [tool: ExCoveralls],
+      elixirc_paths: elixirc_paths(Mix.env())
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
         coveralls: :test,
         "coveralls.circle": :test,
         "coveralls.detail": :test,
@@ -32,9 +39,7 @@ defmodule EDTF.MixProject do
         "vcr.delete": :test,
         "vcr.check": :test,
         "vcr.show": :test
-      ],
-      test_coverage: [tool: ExCoveralls],
-      elixirc_paths: elixirc_paths(Mix.env())
+      ]
     ]
   end
 

--- a/test/edtf/date_range_test.exs
+++ b/test/edtf/date_range_test.exs
@@ -1,0 +1,270 @@
+defmodule EDTF.DateRangeTest do
+  use ExUnit.Case
+
+  describe "to_date_range/1 — dates" do
+    test "full date" do
+      assert EDTF.to_date_range("1999-06-10") == {:ok, {~D[1999-06-10], ~D[1999-06-10]}}
+    end
+
+    test "year and month" do
+      assert EDTF.to_date_range("1999-06") == {:ok, {~D[1999-06-01], ~D[1999-06-30]}}
+    end
+
+    test "year and month honors leap years" do
+      assert EDTF.to_date_range("2024-02") == {:ok, {~D[2024-02-01], ~D[2024-02-29]}}
+      assert EDTF.to_date_range("2023-02") == {:ok, {~D[2023-02-01], ~D[2023-02-28]}}
+    end
+
+    test "year only" do
+      assert EDTF.to_date_range("1999") == {:ok, {~D[1999-01-01], ~D[1999-12-31]}}
+    end
+
+    test "decade" do
+      assert EDTF.to_date_range("201") == {:ok, {~D[2010-01-01], ~D[2019-12-31]}}
+    end
+
+    test "century" do
+      assert EDTF.to_date_range("19") == {:ok, {~D[1900-01-01], ~D[1999-12-31]}}
+      assert EDTF.to_date_range("20") == {:ok, {~D[2000-01-01], ~D[2099-12-31]}}
+    end
+
+    test "Y-prefixed year within Calendar.ISO range" do
+      assert EDTF.to_date_range("Y2020") == {:ok, {~D[2020-01-01], ~D[2020-12-31]}}
+    end
+  end
+
+  describe "to_date_range/1 — unspecified digits" do
+    test "year units (decade equivalent)" do
+      assert EDTF.to_date_range("192X") == {:ok, {~D[1920-01-01], ~D[1929-12-31]}}
+    end
+
+    test "year tens and units (century equivalent)" do
+      assert EDTF.to_date_range("19XX") == {:ok, {~D[1900-01-01], ~D[1999-12-31]}}
+    end
+
+    test "year hundreds, tens, and units (millennium equivalent)" do
+      assert EDTF.to_date_range("1XXX") == {:ok, {~D[1000-01-01], ~D[1999-12-31]}}
+    end
+
+    test "fully-unknown year is unsupported" do
+      assert EDTF.to_date_range("XXXX") == {:error, :unsupported}
+    end
+
+    test "non-suffix unspecified digits are unsupported" do
+      assert EDTF.to_date_range("X9X2") == {:error, :unsupported}
+    end
+
+    test "month-component unspecified widens to the full year" do
+      assert EDTF.to_date_range("1999-XX") == {:ok, {~D[1999-01-01], ~D[1999-12-31]}}
+    end
+
+    test "day-component unspecified widens to the full month" do
+      assert EDTF.to_date_range("1999-12-XX") == {:ok, {~D[1999-12-01], ~D[1999-12-31]}}
+    end
+  end
+
+  describe "to_date_range/1 — seasons" do
+    test "spring (northern hemisphere default)" do
+      assert EDTF.to_date_range("2020-21") == {:ok, {~D[2020-03-01], ~D[2020-05-31]}}
+    end
+
+    test "summer, autumn" do
+      assert EDTF.to_date_range("2020-22") == {:ok, {~D[2020-06-01], ~D[2020-08-31]}}
+      assert EDTF.to_date_range("2020-23") == {:ok, {~D[2020-09-01], ~D[2020-11-30]}}
+    end
+
+    test "winter (northern hemisphere) spans the year boundary" do
+      assert EDTF.to_date_range("2020-24") == {:ok, {~D[2020-12-01], ~D[2021-02-28]}}
+    end
+
+    test "winter (northern hemisphere) end honors leap year" do
+      assert EDTF.to_date_range("2023-24") == {:ok, {~D[2023-12-01], ~D[2024-02-29]}}
+    end
+
+    test "southern hemisphere seasons" do
+      assert EDTF.to_date_range("2020-29") == {:ok, {~D[2020-09-01], ~D[2020-11-30]}}
+      assert EDTF.to_date_range("2020-30") == {:ok, {~D[2020-12-01], ~D[2021-02-28]}}
+      assert EDTF.to_date_range("2020-31") == {:ok, {~D[2020-03-01], ~D[2020-05-31]}}
+      assert EDTF.to_date_range("2020-32") == {:ok, {~D[2020-06-01], ~D[2020-08-31]}}
+    end
+
+    test "quarters" do
+      assert EDTF.to_date_range("2020-33") == {:ok, {~D[2020-01-01], ~D[2020-03-31]}}
+      assert EDTF.to_date_range("2020-34") == {:ok, {~D[2020-04-01], ~D[2020-06-30]}}
+      assert EDTF.to_date_range("2020-35") == {:ok, {~D[2020-07-01], ~D[2020-09-30]}}
+      assert EDTF.to_date_range("2020-36") == {:ok, {~D[2020-10-01], ~D[2020-12-31]}}
+    end
+
+    test "quadrimesters and semesters" do
+      assert EDTF.to_date_range("2020-37") == {:ok, {~D[2020-01-01], ~D[2020-04-30]}}
+      assert EDTF.to_date_range("2020-38") == {:ok, {~D[2020-05-01], ~D[2020-08-31]}}
+      assert EDTF.to_date_range("2020-39") == {:ok, {~D[2020-09-01], ~D[2020-12-31]}}
+      assert EDTF.to_date_range("2020-40") == {:ok, {~D[2020-01-01], ~D[2020-06-30]}}
+      assert EDTF.to_date_range("2020-41") == {:ok, {~D[2020-07-01], ~D[2020-12-31]}}
+    end
+  end
+
+  describe "to_date_range/1 — qualifiers ignored" do
+    test "approximate" do
+      assert EDTF.to_date_range("1985~") == {:ok, {~D[1985-01-01], ~D[1985-12-31]}}
+    end
+
+    test "uncertain" do
+      assert EDTF.to_date_range("1985?") == {:ok, {~D[1985-01-01], ~D[1985-12-31]}}
+    end
+
+    test "approximate-and-uncertain" do
+      assert EDTF.to_date_range("1985-06%") == {:ok, {~D[1985-06-01], ~D[1985-06-30]}}
+    end
+
+    test "level-2 component qualifier" do
+      assert EDTF.to_date_range("2024-~10") == {:ok, {~D[2024-10-01], ~D[2024-10-31]}}
+    end
+  end
+
+  describe "to_date_range/1 — intervals" do
+    test "bounded date interval" do
+      assert EDTF.to_date_range("1985-04-12/1985-06-26") ==
+               {:ok, {~D[1985-04-12], ~D[1985-06-26]}}
+    end
+
+    test "year-only intervals widen to year boundaries" do
+      assert EDTF.to_date_range("1985/1990") == {:ok, {~D[1985-01-01], ~D[1990-12-31]}}
+    end
+
+    test "open end (..)" do
+      assert EDTF.to_date_range("1985/..") == {:ok, {~D[1985-01-01], nil}}
+    end
+
+    test "open start (..)" do
+      assert EDTF.to_date_range("../1985") == {:ok, {nil, ~D[1985-12-31]}}
+    end
+
+    test "unknown end" do
+      assert EDTF.to_date_range("1985/") == {:ok, {~D[1985-01-01], nil}}
+    end
+
+    test "unknown start" do
+      assert EDTF.to_date_range("/1985") == {:ok, {nil, ~D[1985-12-31]}}
+    end
+
+    test "reversed interval is normalized to chronological order" do
+      assert EDTF.to_date_range("1999/1980") == {:ok, {~D[1980-01-01], ~D[1999-12-31]}}
+    end
+
+    test "reversed year-month interval is normalized" do
+      assert EDTF.to_date_range("1985-06/1985-04") ==
+               {:ok, {~D[1985-04-01], ~D[1985-06-30]}}
+    end
+
+    test "reversed full-date interval is normalized" do
+      assert EDTF.to_date_range("1985-06-26/1985-04-12") ==
+               {:ok, {~D[1985-04-12], ~D[1985-06-26]}}
+    end
+  end
+
+  describe "to_date_range/1 — aggregates" do
+    test "list of bare years" do
+      assert EDTF.to_date_range("[1667, 1668, 1670]") ==
+               {:ok, {~D[1667-01-01], ~D[1670-12-31]}}
+    end
+
+    test "list with a sub-interval" do
+      assert EDTF.to_date_range("[1667, 1668, 1670..1672]") ==
+               {:ok, {~D[1667-01-01], ~D[1672-12-31]}}
+    end
+
+    test "set of year-months" do
+      assert EDTF.to_date_range("{2019-06, 2020-06}") ==
+               {:ok, {~D[2019-06-01], ~D[2020-06-30]}}
+    end
+
+    test "earlier continuation" do
+      assert EDTF.to_date_range("[..2020]") == {:ok, {nil, ~D[2020-12-31]}}
+    end
+
+    test "later continuation" do
+      assert EDTF.to_date_range("[2020..]") == {:ok, {~D[2020-01-01], nil}}
+    end
+
+    test "earlier and later continuations" do
+      assert EDTF.to_date_range("[..2018, 2020..]") == {:ok, {nil, nil}}
+    end
+  end
+
+  describe "to_date_range/1 — BCE" do
+    test "BCE year" do
+      assert EDTF.to_date_range("-0044") == {:ok, {~D[-0044-01-01], ~D[-0044-12-31]}}
+    end
+
+    test "BCE year-month" do
+      assert EDTF.to_date_range("-1985-06") == {:ok, {~D[-1985-06-01], ~D[-1985-06-30]}}
+    end
+
+    test "BCE full date" do
+      assert EDTF.to_date_range("-1985-06-10") == {:ok, {~D[-1985-06-10], ~D[-1985-06-10]}}
+    end
+
+    test "BCE decade widens toward deeper antiquity (matches humanize \"2010s BCE\")" do
+      assert EDTF.to_date_range("-201") == {:ok, {~D[-2019-01-01], ~D[-2010-12-31]}}
+    end
+
+    test "BCE century widens toward deeper antiquity (matches humanize \"19th Century BCE\")" do
+      assert EDTF.to_date_range("-19") == {:ok, {~D[-1999-01-01], ~D[-1900-12-31]}}
+    end
+
+    test "BCE year with unspecified units digit" do
+      assert EDTF.to_date_range("-192X") == {:ok, {~D[-1929-01-01], ~D[-1920-12-31]}}
+    end
+
+    test "BCE season" do
+      assert EDTF.to_date_range("-1985-21") == {:ok, {~D[-1985-03-01], ~D[-1985-05-31]}}
+    end
+
+    test "BCE interval" do
+      assert EDTF.to_date_range("-0100/-0044") == {:ok, {~D[-0100-01-01], ~D[-0044-12-31]}}
+    end
+  end
+
+  describe "to_date_range/1 — extreme years (passed through to Date.new/3)" do
+    test "Y-prefixed year above 9999" do
+      assert EDTF.to_date_range("Y20020") ==
+               {:ok, {Date.new!(20_020, 1, 1), Date.new!(20_020, 12, 31)}}
+    end
+
+    test "exponential year" do
+      assert EDTF.to_date_range("Y17E7") ==
+               {:ok, {Date.new!(170_000_000, 1, 1), Date.new!(170_000_000, 12, 31)}}
+    end
+
+    test "year below -9999" do
+      assert EDTF.to_date_range("Y-20020") ==
+               {:ok, {Date.new!(-20_020, 1, 1), Date.new!(-20_020, 12, 31)}}
+    end
+  end
+
+  describe "to_date_range/1 — errors" do
+    test "invalid format" do
+      assert EDTF.to_date_range("bad date!") == {:error, :invalid_format}
+    end
+  end
+
+  describe "to_date_range/1 — input shapes" do
+    test "accepts a parsed struct" do
+      {:ok, parsed} = EDTF.parse("1985-04-12/1985-06-26")
+
+      assert EDTF.to_date_range(parsed) ==
+               {:ok, {~D[1985-04-12], ~D[1985-06-26]}}
+    end
+
+    test "accepts the {:ok, struct} parse result directly" do
+      assert EDTF.parse("1999") |> EDTF.DateRange.to_date_range() ==
+               {:ok, {~D[1999-01-01], ~D[1999-12-31]}}
+    end
+
+    test "passes through {:error, _} parse failures" do
+      assert EDTF.parse("bad date!") |> EDTF.DateRange.to_date_range() ==
+               {:error, :invalid_format}
+    end
+  end
+end

--- a/test/edtf/date_range_test.exs
+++ b/test/edtf/date_range_test.exs
@@ -133,19 +133,19 @@ defmodule EDTF.DateRangeTest do
     end
 
     test "open end (..)" do
-      assert EDTF.to_date_range("1985/..") == {:ok, {~D[1985-01-01], nil}}
+      assert EDTF.to_date_range("1985/..") == {:ok, {~D[1985-01-01], :unbounded}}
     end
 
     test "open start (..)" do
-      assert EDTF.to_date_range("../1985") == {:ok, {nil, ~D[1985-12-31]}}
+      assert EDTF.to_date_range("../1985") == {:ok, {:unbounded, ~D[1985-12-31]}}
     end
 
     test "unknown end" do
-      assert EDTF.to_date_range("1985/") == {:ok, {~D[1985-01-01], nil}}
+      assert EDTF.to_date_range("1985/") == {:ok, {~D[1985-01-01], :unknown}}
     end
 
     test "unknown start" do
-      assert EDTF.to_date_range("/1985") == {:ok, {nil, ~D[1985-12-31]}}
+      assert EDTF.to_date_range("/1985") == {:ok, {:unknown, ~D[1985-12-31]}}
     end
 
     test "reversed interval is normalized to chronological order" do
@@ -180,15 +180,15 @@ defmodule EDTF.DateRangeTest do
     end
 
     test "earlier continuation" do
-      assert EDTF.to_date_range("[..2020]") == {:ok, {nil, ~D[2020-12-31]}}
+      assert EDTF.to_date_range("[..2020]") == {:ok, {:unbounded, ~D[2020-12-31]}}
     end
 
     test "later continuation" do
-      assert EDTF.to_date_range("[2020..]") == {:ok, {~D[2020-01-01], nil}}
+      assert EDTF.to_date_range("[2020..]") == {:ok, {~D[2020-01-01], :unbounded}}
     end
 
     test "earlier and later continuations" do
-      assert EDTF.to_date_range("[..2018, 2020..]") == {:ok, {nil, nil}}
+      assert EDTF.to_date_range("[..2018, 2020..]") == {:ok, {:unbounded, :unbounded}}
     end
   end
 

--- a/test/edtf_test.exs
+++ b/test/edtf_test.exs
@@ -16,6 +16,11 @@ defmodule EDTFTest do
     assert EDTF.parse("2020-%06-25?") == {:error, :invalid_format}
   end
 
+  test "to_date_range/1" do
+    assert EDTF.to_date_range("2020") == {:ok, {~D[2020-01-01], ~D[2020-12-31]}}
+    assert EDTF.to_date_range("bad date!") == {:error, :invalid_format}
+  end
+
   test "rejects unprefixed short-digit years (ISO 8601-2 requires Y prefix or 4-digit form)" do
     assert EDTF.parse("1") == {:error, :invalid_format}
     assert EDTF.humanize("1") == {:error, :invalid_format}

--- a/test/edtf_test.exs
+++ b/test/edtf_test.exs
@@ -15,4 +15,17 @@ defmodule EDTFTest do
     assert EDTF.parse("bad date!") == {:error, :invalid_format}
     assert EDTF.parse("2020-%06-25?") == {:error, :invalid_format}
   end
+
+  test "rejects unprefixed short-digit years (ISO 8601-2 requires Y prefix or 4-digit form)" do
+    assert EDTF.parse("1") == {:error, :invalid_format}
+    assert EDTF.humanize("1") == {:error, :invalid_format}
+    assert EDTF.validate("1") == {:error, :invalid_format}
+
+    assert EDTF.parse("0001") ==
+             {:ok, %EDTF.Date{level: 0, type: :date, values: [1]}}
+
+    assert EDTF.parse("Y20020") ==
+             {:ok,
+              %EDTF.Date{level: 1, type: :year, values: [20_020], attributes: [significant: nil]}}
+  end
 end


### PR DESCRIPTION
Hi there!

First of all, thank you so much for building and maintaining this library! I'm currently using it in a project for an archive system, and it has been incredibly helpful.

While working with EDTF periods, I realized that it would be very practical for many use cases to easily extract the boundaries of a given timeframe (e.g., when querying databases). 

This PR introduces a new `to_date_range/1` function that takes an EDTF struct and returns a `{start_date, end_date}` tuple using standard Elixir `Date` structs.

### Key Details & Design Decisions:
* **Standard Date Structs:** Returns a tuple of `%Date{}`.
* **Open Intervals:** For open EDTF intervals (e.g., `1985/..`), the function returns `nil` for the unbounded side (e.g., `{~D[1985-01-01], nil}`). This maps nicely to Ecto/SQL for those who want to persist the data.
* **No Artificial Limits:** It relies on Elixir's native capabilities for large integers, so it fully supports years > 9999 or < 0 without arbitrarily capping them. (Database restrictions are out of the scope for this function.)

I have included tests and updated the documentation accordingly. 

Please let me know if you'd like me to change anything about the implementation or naming. I'm happy to adjust it to fit your vision for the library!

Thanks again for your time and work on this!