### PR TITLE
Reject impossible dates & tighten unspecified-digit ranges

### DIFF
--- a/lib/edtf.ex
+++ b/lib/edtf.ex
@@ -3,7 +3,7 @@ defmodule EDTF do
   Parse, validate, and humanize EDTF date strings
   """
 
-  alias EDTF.{Aggregate, Date, Interval, Level}
+  alias EDTF.{Aggregate, Date, Interval, Level, Validate}
 
   @doc """
   Parse an EDTF date string
@@ -15,12 +15,19 @@ defmodule EDTF do
 
     iex> parse("bad date!")
     {:error, :invalid_format}
+
+    iex> parse("1999-02-30")
+    {:error, :invalid_date}
     ```
   """
   def parse(edtf) do
     case EDTF.Parser.parse(edtf) do
-      {:ok, [result], _, _, _, _} -> {:ok, assemble(result) |> Level.add_level()}
-      {:error, _, _, _, _, _} -> {:error, :invalid_format}
+      {:ok, [result], _, _, _, _} ->
+        assembled = assemble(result) |> Level.add_level()
+        if Validate.valid?(assembled), do: {:ok, assembled}, else: {:error, :invalid_date}
+
+      {:error, _, _, _, _, _} ->
+        {:error, :invalid_format}
     end
   end
 
@@ -42,6 +49,9 @@ defmodule EDTF do
 
     iex> validate("bad date!")
     {:error, :invalid_format}
+
+    iex> validate("1999-02-30")
+    {:error, :invalid_date}
     ```
   """
   def validate(edtf) do
@@ -81,10 +91,11 @@ defmodule EDTF do
   the nominal date. Unspecified-digit suffixes (e.g. `19XX`) expand to their
   full span. See `EDTF.DateRange` for the full semantics.
 
-  Returns `{:error, :invalid_format}` when parsing fails, `{:error, :out_of_range}`
-  when `Date.new/3` itself rejects a value, and `{:error, :unsupported}` for
-  shapes the converter declines (e.g. fully-unknown year `XXXX` or non-suffix
-  unspecified digits like `X9X2`).
+  Returns `{:error, :invalid_format}` when the string is malformed,
+  `{:error, :invalid_date}` when it is well-formed but not a real calendar date
+  (e.g. `1999-02-30`), `{:error, :out_of_range}` when `Date.new/3` itself rejects
+  a value, and `{:error, :unsupported}` for shapes the converter declines (e.g.
+  fully-unknown year `XXXX` or non-suffix unspecified digits like `X9X2`).
 
   Example:
     ```elixir

--- a/lib/edtf.ex
+++ b/lib/edtf.ex
@@ -8,6 +8,15 @@ defmodule EDTF do
   @doc """
   Parse an EDTF date string
 
+  Well-formed strings that don't denote a real calendar date (e.g.
+  `"1999-02-30"`) return `{:error, :invalid_date}`. Pass `validate: false` to
+  skip calendar validation and accept the assembled struct anyway — useful when
+  cataloging an item whose stamped date is known to be impossible.
+
+  ## Options
+
+    * `:validate` — when `false`, skip calendar validation. Defaults to `true`.
+
   Example:
     ```elixir
     iex> parse("1999-06-10")
@@ -18,13 +27,23 @@ defmodule EDTF do
 
     iex> parse("1999-02-30")
     {:error, :invalid_date}
+
+    iex> parse("1999-02-30", validate: false)
+    {:ok, %EDTF.Date{level: 0, type: :date, values: [1999, 1, 30]}}
     ```
   """
-  def parse(edtf) do
+  def parse(edtf, opts \\ []) do
+    validate? = Keyword.get(opts, :validate, true)
+
     case EDTF.Parser.parse(edtf) do
       {:ok, [result], _, _, _, _} ->
         assembled = assemble(result) |> Level.add_level()
-        if Validate.valid?(assembled), do: {:ok, assembled}, else: {:error, :invalid_date}
+
+        cond do
+          not validate? -> {:ok, assembled}
+          Validate.valid?(assembled) -> {:ok, assembled}
+          true -> {:error, :invalid_date}
+        end
 
       {:error, _, _, _, _, _} ->
         {:error, :invalid_format}
@@ -64,6 +83,14 @@ defmodule EDTF do
   @doc """
   Humanize an EDTF date string
 
+  Accepts the same options as `parse/2`. Passing `validate: false` lets you
+  render a well-formed but calendar-invalid date (e.g. an impossible stamped
+  date) instead of returning `{:error, :invalid_date}`.
+
+  ## Options
+
+    * `:validate` — when `false`, skip calendar validation. Defaults to `true`.
+
   Example:
     ```elixir
     iex> humanize("1999-06-10")
@@ -71,10 +98,16 @@ defmodule EDTF do
 
     iex> humanize("bad date!")
     {:error, :invalid_format}
+
+    iex> humanize("1999-02-30")
+    {:error, :invalid_date}
+
+    iex> humanize("1999-02-30", validate: false)
+    "February 30, 1999"
     ```
   """
-  def humanize(edtf) do
-    case edtf |> parse() |> EDTF.Humanize.humanize() do
+  def humanize(edtf, opts \\ []) do
+    case edtf |> parse(opts) |> EDTF.Humanize.humanize() do
       :original -> edtf
       other -> other
     end

--- a/lib/edtf/date_range.ex
+++ b/lib/edtf/date_range.ex
@@ -15,9 +15,12 @@ defmodule EDTF.DateRange do
   - Inputs with an unknown bound (`1985/`, `/1985`) yield `:unknown` on that
     side.
   - Qualifiers (`~`, `?`, `%`) are ignored — the range uses the nominal date.
-  - Unspecified digits (`X`) are expanded to their full place-value span when
-    they form a contiguous suffix of a component (e.g. `19XX` → 1900-01-01 to
-    1999-12-31). Non-suffix unspecified digits return `{:error, :unsupported}`.
+  - Unspecified digits (`X`) forming a contiguous suffix of a component expand to
+    that suffix's span: `19XX` → 1900–1999, `2020-1X` → Oct–Dec 2020,
+    `2020-12-3X` → Dec 30–31 2020. A fully-unknown month or day widens to the
+    whole year or month respectively. Non-suffix unknown digits (`X9X2`,
+    `2020-X2`), a fully-unknown year (`XXXX`), and suffixes that can't denote a
+    real date (`2020-02-3X`) return `{:error, :unsupported}`.
   - Seasons map to month ranges (quarters, quadrimesters, semesters are
     unambiguous; codes 21–24 are treated as northern-hemisphere; Winter and
     southern-hemisphere Summer span the year boundary).
@@ -52,6 +55,15 @@ defmodule EDTF.DateRange do
   }
 
   @year_span_for_mask %{0 => 0, 8 => 9, 12 => 99, 14 => 999}
+
+  # Unspecified-mask bit groups (see EDTF.Parser.Helpers.bitmask/6). The `_units`
+  # masks are the trailing digit of a component — the only sub-year suffix that
+  # expands to a clean span; a leading-digit (non-suffix) mask falls through.
+  @year_bits 15
+  @month_bits 48
+  @month_units 32
+  @day_bits 192
+  @day_units 128
 
   @doc """
   Convert a parsed EDTF struct (or a `parse/1` result tuple) into a
@@ -130,33 +142,81 @@ defmodule EDTF.DateRange do
   defp from_date(_), do: {:error, :unsupported}
 
   defp from_unspecified(%EDTF.Date{values: values, type: :date}, mask) do
-    year_bits = mask &&& 15
-    month_bits = mask &&& 48
-    day_bits = mask &&& 192
+    year_bits = mask &&& @year_bits
+    month_bits = mask &&& @month_bits
+    day_bits = mask &&& @day_bits
 
     cond do
-      year_bits == 15 ->
-        {:error, :unsupported}
-
-      year_bits != 0 and not Map.has_key?(@year_span_for_mask, year_bits) ->
-        {:error, :unsupported}
-
-      year_bits != 0 ->
-        span_range(hd(values), Map.fetch!(@year_span_for_mask, year_bits))
-
-      month_bits != 0 ->
-        year_range(hd(values))
-
-      day_bits != 0 and match?([_, _ | _], values) ->
-        [year, month | _] = values
-        month_range(year, month + 1)
-
-      true ->
-        {:error, :unsupported}
+      year_bits != 0 -> unspecified_year_range(values, year_bits)
+      month_bits != 0 -> unspecified_month_range(values, month_bits)
+      day_bits != 0 and match?([_, _ | _], values) -> unspecified_day_range(values, day_bits)
+      true -> {:error, :unsupported}
     end
   end
 
   defp from_unspecified(_, _), do: {:error, :unsupported}
+
+  # Only a contiguous suffix expands cleanly: a fully-unknown or non-suffix year
+  # isn't in the table, so it declines.
+  defp unspecified_year_range([year | _], year_bits) do
+    case Map.get(@year_span_for_mask, year_bits) do
+      nil -> {:error, :unsupported}
+      span -> span_range(year, span)
+    end
+  end
+
+  defp unspecified_month_range([year | _], @month_bits), do: month_span(year, 1, 12)
+
+  defp unspecified_month_range([year, month | _], @month_units) do
+    tens = div(month + 1, 10)
+    month_span(year, tens * 10, tens * 10 + 9)
+  end
+
+  defp unspecified_month_range(_, _), do: {:error, :unsupported}
+
+  defp unspecified_day_range([year, month | _], @day_bits), do: month_range(year, month + 1)
+
+  defp unspecified_day_range([year, month, day], @day_units) do
+    tens = div(day, 10)
+    day_span(year, month + 1, tens * 10, tens * 10 + 9)
+  end
+
+  defp unspecified_day_range(_, _), do: {:error, :unsupported}
+
+  defp month_span(year, low, high) do
+    start_month = max(low, 1)
+    end_month = min(high, 12)
+
+    if start_month > end_month do
+      {:error, :unsupported}
+    else
+      with {:ok, start_date} <- Date.new(year, start_month, 1),
+           {:ok, end_pivot} <- Date.new(year, end_month, 1) do
+        end_date = Date.new!(year, end_month, Date.days_in_month(end_pivot))
+        {:ok, {start_date, end_date}}
+      else
+        _ -> {:error, :out_of_range}
+      end
+    end
+  end
+
+  # An empty span (e.g. `02-3X`: no day 30-39 exists in February) has no range.
+  defp day_span(year, month, low, high) do
+    case Date.new(year, month, 1) do
+      {:ok, first} ->
+        start_day = max(low, 1)
+        end_day = min(high, Date.days_in_month(first))
+
+        if start_day > end_day do
+          {:error, :unsupported}
+        else
+          {:ok, {Date.new!(year, month, start_day), Date.new!(year, month, end_day)}}
+        end
+
+      _ ->
+        {:error, :out_of_range}
+    end
+  end
 
   defp year_range(year), do: span_range(year, 0)
 

--- a/lib/edtf/validate.ex
+++ b/lib/edtf/validate.ex
@@ -1,0 +1,81 @@
+defmodule EDTF.Validate do
+  @moduledoc """
+  Calendar validation for assembled EDTF structs.
+
+  `EDTF.Parser` only checks structure (digit counts and separators), so an
+  impossible value like `"1999-02-30"` or a bad season code matches the shape
+  and parses. `valid?/1` walks an assembled tree and rejects dates that can't
+  denote a real calendar date.
+
+  ## Unspecified digits (`X`)
+
+  A component is validated only when it is *fully concrete*. A component that
+  contains any unspecified digit is treated as a wildcard and trusted, since the
+  author explicitly marked it unknown — e.g. `1999-02-3X` is accepted even though
+  no day 30–39 exists in February, because the day's units digit is unknown.
+
+  But a fully concrete component is always checked, even when a *neighbouring*
+  component is unspecified: `1999-13-XX` and `XXXX-13-01` are rejected (month 13
+  is concrete and impossible), and `19XX-02-30` is rejected (day 30 can't fall in
+  February). When the year is unspecified we can't know whether it is a leap
+  year, so February is allowed up to day 29 (`19XX-02-29` is accepted).
+
+  Qualifiers (`?`, `~`, `%`) don't change the value, so they are always validated.
+  Validation leans on the standard library's proleptic-Gregorian calendar,
+  matching how `EDTF.DateRange` resolves dates.
+  """
+
+  import Bitwise
+
+  alias EDTF.{Aggregate, Date, Interval}
+
+  # Unspecified-mask bit groups (see EDTF.Parser.Helpers.bitmask/6).
+  @year_bits 15
+  @month_bits 48
+  @day_bits 192
+
+  @doc """
+  Return `true` when an assembled EDTF struct represents a real calendar date.
+
+  Recurses into intervals and aggregates so every nested date is checked.
+  Shapes without anything to verify (years, decades, centuries, infinity, open
+  boundaries) are always considered valid.
+  """
+  def valid?(%Interval{start: start_date, end: end_date}),
+    do: valid?(start_date) and valid?(end_date)
+
+  def valid?(%Aggregate{values: values}), do: Enum.all?(values, &valid?/1)
+
+  def valid?(%Date{type: :season, values: [_year, code]} = date),
+    do: unknown?(date, @month_bits) or code in 21..41
+
+  def valid?(%Date{type: :date, values: [_year]}), do: true
+
+  def valid?(%Date{type: :date, values: [_year, _month]} = date), do: month_ok?(date)
+
+  def valid?(%Date{type: :date, values: [_year, _month, _day]} = date),
+    do: month_ok?(date) and day_ok?(date)
+
+  def valid?(_), do: true
+
+  defp month_ok?(%Date{values: [_year, month | _]} = date),
+    do: unknown?(date, @month_bits) or (month + 1) in 1..12
+
+  defp day_ok?(%Date{values: [year, month, day]} = date) do
+    cond do
+      unknown?(date, @day_bits) -> true
+      unknown?(date, @month_bits) -> day in 1..31
+      unknown?(date, @year_bits) -> day in 1..max_day(month + 1)
+      true -> Calendar.ISO.valid_date?(year, month + 1, day)
+    end
+  end
+
+  defp max_day(2), do: 29
+  defp max_day(month) when month in [4, 6, 9, 11], do: 30
+  defp max_day(_), do: 31
+
+  defp unknown?(%Date{attributes: attributes}, bits) do
+    mask = Keyword.get(attributes || [], :unspecified, 0)
+    (mask &&& bits) != 0
+  end
+end

--- a/test/edtf/calendar_validation_test.exs
+++ b/test/edtf/calendar_validation_test.exs
@@ -1,0 +1,144 @@
+defmodule EDTF.CalendarValidationTest do
+  use ExUnit.Case
+
+  describe "parse/1 rejects impossible calendar dates" do
+    test "day out of range for the month" do
+      assert EDTF.parse("1999-02-30") == {:error, :invalid_date}
+      assert EDTF.parse("2021-04-31") == {:error, :invalid_date}
+      assert EDTF.parse("2021-06-31") == {:error, :invalid_date}
+    end
+
+    test "February 29 on a non-leap year" do
+      assert EDTF.parse("1999-02-29") == {:error, :invalid_date}
+      assert EDTF.parse("1900-02-29") == {:error, :invalid_date}
+    end
+
+    test "month out of range" do
+      assert EDTF.parse("1999-00-15") == {:error, :invalid_date}
+      assert EDTF.parse("1999-13-01") == {:error, :invalid_date}
+      assert EDTF.parse("1999-00") == {:error, :invalid_date}
+    end
+
+    test "qualified but concrete impossible dates are still rejected" do
+      assert EDTF.parse("1999-02-30?") == {:error, :invalid_date}
+      assert EDTF.parse("1999-02-30~") == {:error, :invalid_date}
+      assert EDTF.parse("1999-02-30%") == {:error, :invalid_date}
+    end
+
+    test "invalid dates inside intervals" do
+      assert EDTF.parse("1999-02-30/2000-01-01") == {:error, :invalid_date}
+      assert EDTF.parse("2000-01-01/1999-02-30") == {:error, :invalid_date}
+    end
+
+    test "invalid dates inside lists and sets" do
+      assert EDTF.parse("{1999-01-01,1999-02-30}") == {:error, :invalid_date}
+      assert EDTF.parse("[1999-02-30,2000-01-01]") == {:error, :invalid_date}
+    end
+  end
+
+  describe "parse/1 rejects out-of-range season codes" do
+    test "codes below the season range" do
+      assert EDTF.parse("1999-13") == {:error, :invalid_date}
+      assert EDTF.parse("1999-20") == {:error, :invalid_date}
+    end
+
+    test "codes above the season range" do
+      assert EDTF.parse("1999-42") == {:error, :invalid_date}
+    end
+
+    test "valid season codes are accepted" do
+      assert {:ok, %EDTF.Date{type: :season, values: [1999, 21]}} = EDTF.parse("1999-21")
+      assert {:ok, %EDTF.Date{type: :season, values: [1999, 41]}} = EDTF.parse("1999-41")
+    end
+  end
+
+  describe "parse/1 accepts real dates" do
+    test "ordinary valid dates" do
+      assert {:ok, %EDTF.Date{values: [1999, 1, 28]}} = EDTF.parse("1999-02-28")
+      assert {:ok, %EDTF.Date{values: [2021, 11, 31]}} = EDTF.parse("2021-12-31")
+    end
+
+    test "February 29 on leap years" do
+      assert {:ok, %EDTF.Date{values: [2000, 1, 29]}} = EDTF.parse("2000-02-29")
+      assert {:ok, %EDTF.Date{values: [2024, 1, 29]}} = EDTF.parse("2024-02-29")
+    end
+
+    test "BCE and year-zero dates use the proleptic Gregorian calendar" do
+      assert {:ok, %EDTF.Date{values: [0, 1, 29]}} = EDTF.parse("0000-02-29")
+      assert EDTF.parse("0000-02-30") == {:error, :invalid_date}
+      assert {:ok, %EDTF.Date{values: [-44, 2, 15]}} = EDTF.parse("-0044-03-15")
+      assert EDTF.parse("-2000-02-30") == {:error, :invalid_date}
+    end
+
+    test "year-only and year-month dates" do
+      assert {:ok, %EDTF.Date{values: [1999]}} = EDTF.parse("1999")
+      assert {:ok, %EDTF.Date{values: [1999, 1]}} = EDTF.parse("1999-02")
+    end
+
+    test "large Y-form years carry no day and are unaffected" do
+      assert {:ok, %EDTF.Date{type: :year, values: [170_000_000]}} = EDTF.parse("Y170000000")
+      assert {:ok, %EDTF.Date{type: :year, values: [-170_000_000]}} = EDTF.parse("Y-170000000")
+    end
+  end
+
+  describe "parse/1 with unspecified digits — wildcard components are trusted" do
+    test "a component containing X is not second-guessed" do
+      # February has no day 30-39, but the day's units digit is unknown.
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("1999-02-3X")
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("1999-02-XX")
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("1999-0X-30")
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("19XX")
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("1999-1X")
+    end
+
+    test "a fully concrete out-of-range day is still rejected" do
+      assert EDTF.parse("1999-02-39") == {:error, :invalid_date}
+    end
+  end
+
+  describe "parse/1 with unspecified digits — concrete neighbours are still validated" do
+    test "a concrete impossible month is rejected even when the day is unknown" do
+      assert EDTF.parse("1999-13-XX") == {:error, :invalid_date}
+      assert EDTF.parse("1999-00-XX") == {:error, :invalid_date}
+    end
+
+    test "a concrete impossible month is rejected even when the year is unknown" do
+      assert EDTF.parse("XXXX-13-01") == {:error, :invalid_date}
+    end
+
+    test "a concrete out-of-range day is rejected even when the month is unknown" do
+      assert EDTF.parse("1999-XX-32") == {:error, :invalid_date}
+      assert EDTF.parse("1999-XX-00") == {:error, :invalid_date}
+    end
+
+    test "a concrete day that some month can host is accepted when month is unknown" do
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("1999-XX-31")
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("1999-XX-30")
+    end
+
+    test "an unknown year allows February up to day 29 but not beyond" do
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("19XX-02-29")
+      assert {:ok, %EDTF.Date{}} = EDTF.parse("199X-02-29")
+      assert EDTF.parse("19XX-02-30") == {:error, :invalid_date}
+    end
+
+    test "an unknown season-code digit is trusted, a concrete bad code is rejected" do
+      assert {:ok, %EDTF.Date{type: :season}} = EDTF.parse("1999-2X")
+      assert EDTF.parse("1999-42") == {:error, :invalid_date}
+    end
+  end
+
+  describe "validate/1 surfaces the same result" do
+    test "rejects impossible dates" do
+      assert EDTF.validate("1999-02-30") == {:error, :invalid_date}
+    end
+
+    test "accepts real dates" do
+      assert EDTF.validate("1999-02-28") == {:ok, "1999-02-28"}
+    end
+
+    test "still distinguishes malformed input" do
+      assert EDTF.validate("bad date!") == {:error, :invalid_format}
+    end
+  end
+end

--- a/test/edtf/date_range_test.exs
+++ b/test/edtf/date_range_test.exs
@@ -61,6 +61,30 @@ defmodule EDTF.DateRangeTest do
     test "day-component unspecified widens to the full month" do
       assert EDTF.to_date_range("1999-12-XX") == {:ok, {~D[1999-12-01], ~D[1999-12-31]}}
     end
+
+    test "partial month suffix narrows to that block of months" do
+      assert EDTF.to_date_range("2020-1X") == {:ok, {~D[2020-10-01], ~D[2020-12-31]}}
+      assert EDTF.to_date_range("2020-0X") == {:ok, {~D[2020-01-01], ~D[2020-09-30]}}
+    end
+
+    test "partial day suffix narrows to that block of days" do
+      assert EDTF.to_date_range("2020-12-3X") == {:ok, {~D[2020-12-30], ~D[2020-12-31]}}
+      assert EDTF.to_date_range("2020-12-0X") == {:ok, {~D[2020-12-01], ~D[2020-12-09]}}
+    end
+
+    test "partial day suffix is clamped to the real length of the month" do
+      assert EDTF.to_date_range("2020-04-3X") == {:ok, {~D[2020-04-30], ~D[2020-04-30]}}
+    end
+
+    test "a suffix that can't denote a real date is unsupported" do
+      # No day 30-39 exists in February.
+      assert EDTF.to_date_range("2020-02-3X") == {:error, :unsupported}
+    end
+
+    test "non-suffix month or day digits are unsupported" do
+      assert EDTF.to_date_range("2020-X2") == {:error, :unsupported}
+      assert EDTF.to_date_range("2020-12-X5") == {:error, :unsupported}
+    end
   end
 
   describe "to_date_range/1 — seasons" do

--- a/test/edtf_test.exs
+++ b/test/edtf_test.exs
@@ -16,6 +16,25 @@ defmodule EDTFTest do
     assert EDTF.parse("2020-%06-25?") == {:error, :invalid_format}
   end
 
+  test "parse/2 with validate: false accepts calendar-invalid dates" do
+    assert EDTF.parse("1999-02-30") == {:error, :invalid_date}
+
+    assert EDTF.parse("1999-02-30", validate: false) ==
+             {:ok, %EDTF.Date{level: 0, type: :date, values: [1999, 1, 30]}}
+
+    # validate: true is the default and still rejects.
+    assert EDTF.parse("1999-02-30", validate: true) == {:error, :invalid_date}
+
+    # Bypassing validation does not bypass format checks.
+    assert EDTF.parse("bad date!", validate: false) == {:error, :invalid_format}
+  end
+
+  test "humanize/2 with validate: false renders calendar-invalid dates" do
+    assert EDTF.humanize("1999-02-30") == {:error, :invalid_date}
+    assert EDTF.humanize("1999-02-30", validate: false) == "February 30, 1999"
+    assert EDTF.humanize("bad date!", validate: false) == {:error, :invalid_format}
+  end
+
   test "to_date_range/1" do
     assert EDTF.to_date_range("2020") == {:ok, {~D[2020-01-01], ~D[2020-12-31]}}
     assert EDTF.to_date_range("bad date!") == {:error, :invalid_format}


### PR DESCRIPTION
Hey there I found another issue using this lib in my project and I think we all can benefit from my changes. 

parse/1 now validates the calendar, not just the format.

The parser only checked structure, so "1999-02-30" parsed as {:ok, …}. A new EDTF.Validate stage rejects dates that can't denote a real day, returning a distinct {:error, :invalid_date}. The validation runs after the parse stage.

to_date_range/1 expands suffix X digits to tight spans

Previously partial month/day digits widened to the whole year/month. Now a contiguous suffix expands to its real span:

- 2020-1X → Oct–Dec 2020, 2020-12-3X → Dec 30–31
- non-suffix (2020-X2) → :unsupported